### PR TITLE
Fix: possible millis() overflow & behavior of buttons on pins without PWM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .vscode/c_cpp_properties.json
 .vscode/extensions.json
 .vscode/launch.json
+/compile_commands.json

--- a/examples/leds/led_blink/led_blink.ino
+++ b/examples/leds/led_blink/led_blink.ino
@@ -5,34 +5,41 @@
   This sketch demonstrates the basic implementation of how to setup and control a blinking LED.
   
   Usage:
-  Create a button with reference to:
-  - Signal pin         (required) The pin your LED is hooked up to.
+  Create an LED with reference to:
+  - Signal pin (required) - The pin your LED is hooked up to.
+
+  For PWM-capable pins (brightness control):
+  - CtrlLed led(pin, maxBrightness);  // Enable PWM mode with brightness control
+
+  For non-PWM pins (simple on/off):
+  - CtrlLed led(pin);                 // Enable digital mode, on/off only
 
   Available methods:
   - turnOn()              Turns on the LED.
   - turnOff()             Turns off the LED.
   - toggle()              Toggles the LED's off/on status.
-  - setMaxBrightness(255) Sets the maximum brightness of the LED, for calibration purposes (0 - 255).
-  - setBrightness(100)    Sets the brightness of the LED in percentages (0 - 100).
+  - setMaxBrightness(255) Sets the maximum brightness (PWM mode only).
+  - setBrightness(100)    Sets the brightness in percentages (PWM mode only).
   - getMaxBrightness()    Returns the maximum brightness set for the LED.
   - getBrightness()       Returns the brightness of the LED.
   - isOn()                Checks if the LED is turned on.
   - isOff()               Checks if the LED is turned off.
+  - isPwmMode()           Checks if the LED is in PWM mode.
 */
 
 #include <CtrlLed.h>
 
-/* Create an LED with the pin number, and maximum brightness.
-   The maximum brightness can be used to calibrate an LED in case
-   you are using LED's that have a different maximum brightness (optional).
-*/
-CtrlLed led(LED_BUILTIN, 50);
+// Digital mode example (non-PWM pin).
+// This assumes you have connected your LED to a pin without the need for PWM:
+CtrlLed led(LED_BUILTIN);
+
+// PWM mode example (connect to a PWM-capable pin with brightness control):
+// Uncomment the line below and comment out the line above to use PWM mode
+// CtrlLed led(LED_BUILTIN, 255);
 
 void setup()
 {
-  // Turn on the LED and set the brightness to 100%.
-  led.turnOn();
-  led.setBrightness(100);
+  // Initialize the LED (nothing special needed for digital mode).
 }
 
 void loop() {

--- a/examples/leds/led_fade/led_fade.ino
+++ b/examples/leds/led_fade/led_fade.ino
@@ -3,29 +3,37 @@
 
   Description:
   This sketch demonstrates the basic implementation of how to setup and control a fading LED.
+  This example requires a PWM-capable pin for brightness control.
   
   Usage:
-  Create a button with reference to:
-  - Signal pin         (required) The pin your LED is hooked up to.
+  Create an LED with reference to:
+  - Signal pin (required) - The pin your LED is hooked up to (must be PWM-capable).
+
+  For PWM-capable pins (brightness control):
+  - CtrlLed led(pin, maxBrightness);  // Enable PWM mode with brightness control
+
+  For non-PWM pins (simple on/off):
+  - CtrlLed led(pin);                 // Enable digital mode, on/off only
 
   Available methods:
   - turnOn()              Turns on the LED.
   - turnOff()             Turns off the LED.
   - toggle()              Toggles the LED's off/on status.
-  - setMaxBrightness(255) Sets the maximum brightness of the LED, for calibration purposes (0 - 255).
-  - setBrightness(100)    Sets the brightness of the LED in percentages (0 - 100).
+  - setMaxBrightness(255) Sets the maximum brightness (PWM mode only).
+  - setBrightness(100)    Sets the brightness in percentages (PWM mode only).
   - getMaxBrightness()    Returns the maximum brightness set for the LED.
   - getBrightness()       Returns the brightness of the LED.
   - isOn()                Checks if the LED is turned on.
   - isOff()               Checks if the LED is turned off.
+  - isPwmMode()           Checks if the LED is in PWM mode.
 */
 
 #include <CtrlLed.h>
 
-/* Create an LED with the pin number, and maximum brightness.
-   The maximum brightness can be used to calibrate an LED in case
-   you are using LED's that have a different maximum brightness.
-*/
+// PWM mode example (PWM-capable pin with brightness control):
+// This assumes you have connected your LED to a pin with PWM capabilities:
+// The maximum brightness (second parameter) can be used to calibrate an LED,
+// in case you are using multiple LEDs that have different maximum brightness.
 CtrlLed led(LED_BUILTIN, 50);
 
 void setup()

--- a/repo.md
+++ b/repo.md
@@ -1,0 +1,172 @@
+# CTRL Arduino Library Repository
+
+## Project Overview
+
+**CTRL** is an Arduino library that provides easy-to-use interfaces for controlling hardware components commonly used in Arduino projects. It supports buttons, rotary encoders, potentiometers, LEDs, and multiplexers with built-in debouncing, smooth input handling, and flexible instantiation methods.
+
+- **Repository**: [bonkmachines/ctrl-arduino](https://github.com/bonkmachines/ctrl-arduino)
+- **Version**: 1.5.1
+- **Author**: Johannes Jan Prins <johannesprins@knalgeel.com>
+- **License**: See LICENSE file
+- **Category**: Device Control
+
+## Project Structure
+
+```
+ctrl-arduino/
+├── src/                          # Library source code
+│   ├── CTRL.h                    # Main library header
+│   ├── CtrlBase.h/cpp            # Base controller class
+│   ├── CtrlBtn.h/cpp             # Button controller
+│   ├── CtrlEnc.h/cpp             # Rotary encoder controller
+│   ├── CtrlPot.h/cpp             # Potentiometer controller
+│   ├── CtrlLed.h/cpp             # LED controller
+│   ├── CtrlMux.h/cpp             # Multiplexer controller
+│   ├── CtrlGroup.h/cpp           # Group controller for managing multiple devices
+│   ├── Groupable.h/cpp           # Mixin for groupable devices
+│   ├── Muxable.h/cpp             # Mixin for multiplexer-compatible devices
+│   └── main.cpp                  # Main entry point
+├── test/                         # Unit tests (Unity framework)
+│   ├── test_button_*.cpp         # Button unit tests
+│   ├── test_encoder_*.cpp        # Encoder unit tests
+│   ├── test_potentiometer_*.cpp  # Potentiometer unit tests
+│   ├── test_led.cpp              # LED unit tests
+│   ├── test_group_*.cpp          # Group unit tests
+│   ├── test_mulitiplexer_*.cpp   # Multiplexer unit tests
+│   ├── test_main.cpp             # Test runner
+│   ├── test_globals.h/cpp        # Global test utilities
+│   └── unity_config.h            # Unity framework configuration
+├── examples/                     # Example sketches
+│   ├── buttons/                  # Button examples
+│   ├── rotary_encoders/          # Encoder examples
+│   ├── potentiometers/           # Potentiometer examples
+│   ├── leds/                     # LED examples
+│   ├── multiplexers/             # Multiplexer examples
+│   └── groups/                   # Group examples
+├── docs/                         # Documentation
+│   ├── README.md                 # Documentation index
+│   ├── buttons.md                # Button implementation guide
+│   ├── rotary_encoders.md        # Encoder implementation guide
+│   ├── potentiometers.md         # Potentiometer implementation guide
+│   └── multiplexers.md           # Multiplexer implementation guide
+├── .github/                      # GitHub configuration
+│   └── workflows/                # CI/CD workflows
+├── assets/                       # Repository assets (images, logos)
+├── platformio.ini                # PlatformIO configuration
+├── library.properties            # Arduino library metadata
+├── README.md                     # Main project readme
+├── LICENSE                       # License file
+└── .gitignore                    # Git ignore rules
+
+```
+
+## Core Components
+
+### Controllers
+
+- **CtrlBtn** - Debounced button input with press/release callbacks
+- **CtrlEnc** - Rotary encoder with rotation detection
+- **CtrlPot** - Potentiometer input with smooth value handling
+- **CtrlLed** - LED control with blinking/flashing patterns
+- **CtrlMux** - Multiplexer support for expanding I/O capacity
+- **CtrlGroup** - Group multiple controllers for batch operations
+
+### Mixins
+
+- **Groupable** - Allows devices to be part of a group
+- **Muxable** - Enables device support for multiplexers
+
+## Technologies & Tools
+
+- **Language**: C++ (Arduino)
+- **Build System**: PlatformIO
+- **Testing Framework**: Unity
+- **Hardware Targets**:
+  - Teensy 4.1 (primary development board)
+  - Arduino UNO (supported)
+- **CI/CD**: GitHub Actions
+
+## Configuration
+
+### Build Environments (platformio.ini)
+
+- **teensy41**: Development environment for Teensy 4.1 @ 24MHz
+- **uno**: Arduino UNO support
+- **ci**: Testing environment with Unity framework and code coverage
+
+## Key Features
+
+- Multiple hardware targets (Teensy, Arduino UNO)
+- Uniform, flexible interfaces
+- Debouncing for buttons and encoders
+- Smooth potentiometer input handling
+- Group management for multiple devices
+- Multiplexer support for I/O expansion
+- Comprehensive unit test coverage
+- Full code examples for all components
+- Detailed documentation
+
+## Testing
+
+The project includes comprehensive unit tests covering:
+
+- Button states (basic, advanced, pull-up, pull-down, alternative)
+- Encoder operations (basic, advanced, pull-up, pull-down, alternative)
+- Potentiometer input (basic, advanced, common, alternative)
+- LED functionality
+- Grouping operations
+- Multiplexer integration
+
+Tests run on the `ci` environment using the Unity framework with code coverage tracking.
+
+## Installation
+
+### Arduino IDE
+1. Open Library Manager
+2. Search for "CTRL"
+3. Click "INSTALL"
+
+### Manual Installation
+1. Download latest release from [GitHub Releases](https://github.com/bonkmachines/ctrl-arduino/releases)
+2. Arduino IDE → Sketch → Include Library → Add .ZIP Library
+3. Select the downloaded file
+
+## Basic Usage
+
+```cpp
+#include <CtrlBtn.h>
+
+void onPress() {
+  Serial.println("Button pressed");
+}
+
+void onRelease() {
+  Serial.println("Button released");
+}
+
+// pin: 1, debounce: 15ms, onPress callback, onRelease callback
+CtrlBtn button(1, 15, onPress, onRelease);
+
+void setup() {
+  Serial.begin(9600);
+}
+
+void loop() {
+  button.process();
+}
+```
+
+## Development
+
+- **Contact**: johannesprins@knalgeel.com
+- **GitHub**: https://github.com/bonkmachines/ctrl-arduino
+- **Issues & Features**: Submit via GitHub Issues
+
+## CI/CD Status
+
+The project uses GitHub Actions workflows for:
+- Unit testing
+- Example compilation
+- Spell checking
+
+See `.github/workflows/` for details.

--- a/src/CtrlBase.cpp
+++ b/src/CtrlBase.cpp
@@ -49,16 +49,16 @@ bool CtrlBase::isDisabled() const
 
 void setDelayMicroseconds(const uint64_t duration)
 {
-    const uint64_t startTime = micros();
-    const uint64_t targetTime = startTime + duration;
-    while (micros() < targetTime) { }
+    const unsigned long startTime = micros();
+
+    while (micros() - startTime < duration) { }
 }
 
 void setDelayMilliseconds(const uint64_t duration)
 {
-    const uint64_t startTime = millis();
-    const uint64_t targetTime = startTime + duration;
-    while (millis() < targetTime) { }
+    const unsigned long startTime = millis();
+
+    while (millis() - startTime < duration) { }
 }
 
 uint8_t DISCONNECTED = UINT8_MAX;

--- a/src/CtrlLed.h
+++ b/src/CtrlLed.h
@@ -35,23 +35,36 @@ class CtrlLed
     protected:
         uint8_t sig; // Signal pin connected to the LED
         bool on; // Current state of the LED
-        uint8_t brightness; // Current brightness level
-        uint8_t maxBrightness; // Maximum brightness value
+        uint8_t brightness; // Current brightness level (PWM mode only)
+        uint8_t maxBrightness; // Maximum brightness value (PWM mode only)
+        bool pwmMode; // True if LED is on a PWM-capable pin, false for digital pins
 
     public:
         /**
-        * @brief Instantiate an LED object.
+        * @brief Instantiate an LED object for a PWM-capable pin.
         *
         * The CtrlLed class can be instantiated to allow LED objects to be controlled.
+        * When maxBrightness is provided, PWM mode is enabled for brightness control.
         *
         * @param sig (uint8_t) The signal pin of the LED.
-        * @param maxBrightness (uint8_t) (optional) Sets the maximum brightness of the LED, for calibration purposes (0 - 255). Default is 255.
-        * @return A new instance of the CtrlLed class.
+        * @param maxBrightness (uint8_t) Sets the maximum brightness of the LED, for calibration purposes (0 - 255). PWM mode enabled.
+        * @return A new instance of the CtrlLed class in PWM mode.
         */
         explicit CtrlLed(
             uint8_t sig,
-            uint8_t maxBrightness = 255
+            uint8_t maxBrightness
         );
+
+        /**
+        * @brief Instantiate an LED object for a digital (non-PWM) pin.
+        *
+        * The CtrlLed class can be instantiated to allow LED objects to be controlled.
+        * When maxBrightness is omitted, digital mode is enabled for on/off control only.
+        *
+        * @param sig (uint8_t) The signal pin of the LED.
+        * @return A new instance of the CtrlLed class in digital mode.
+        */
+        explicit CtrlLed(uint8_t sig);
 
         /**
         * @brief Toggles the LED's off/on status.
@@ -69,16 +82,22 @@ class CtrlLed
         void turnOff();
 
         /**
-        * @brief Sets the maximum brightness of the LED, for calibration purposes.
+        * @brief Sets the maximum brightness of the LED, for calibration purposes (PWM mode only).
+        *
+        * This method is only available when the LED is connected to a PWM-capable pin.
+        * In digital mode, this method is ignored.
         *
         * @param maxBrightness (int) Sets the maximum brightness of the LED, for calibration purposes (0 - 255).
         */
         void setMaxBrightness(int maxBrightness);
 
         /**
-        * @brief Sets the brightness of the LED in percentages.
+        * @brief Sets the brightness of the LED in percentages (PWM mode only).
         *
-        * @param percentage (int) Sets the maximum brightness. (0 - 100).
+        * This method is only available when the LED is connected to a PWM-capable pin.
+        * In digital mode, this method is ignored.
+        *
+        * @param percentage (int) Sets the brightness. (0 - 100).
         */
         void setBrightness(int percentage);
 
@@ -109,6 +128,13 @@ class CtrlLed
         * @return True if the LED is turned off, false otherwise.
         */
         [[nodiscard]] bool isOff() const;
+
+        /**
+        * @brief Checks if the LED is in PWM mode.
+        *
+        * @return True if the LED is connected to a PWM-capable pin, false if in digital mode.
+        */
+        [[nodiscard]] bool isPwmMode() const;
 
     protected:
         static void processOutput(uint8_t sig, uint8_t brightness);

--- a/test/test_led.cpp
+++ b/test/test_led.cpp
@@ -71,7 +71,7 @@ void test_led_cant_change_brightness_beyond_minimum()
 
 void test_led_can_be_calibrated()
 {
-    CtrlLed led(1);
+    CtrlLed led(1, 255);
 
     led.setMaxBrightness(50);
 
@@ -80,7 +80,7 @@ void test_led_can_be_calibrated()
 
 void test_led_cant_be_calibrated_beyond_maximum()
 {
-    CtrlLed led(1);
+    CtrlLed led(1, 255);
 
     led.setMaxBrightness(256);
 


### PR DESCRIPTION
- Fixed an issue where the usage of micros() & millis() could possible overflow the running application
- Allowing proper usage of buttons that are connected to a pin without PWM capabilities